### PR TITLE
Allow connecting by IP or hostname

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,4 @@
-localhost:80 {
+:80 {
     root * /app
     file_server
     encode zstd gzip


### PR DESCRIPTION
Allow connecting by IP or hostname other than localhost.
In my use case I installed blocky and frontend on my NAS using docker-compose and if I go to NAS_IP:81 I see white page.
With this change in caddyfile inside container and `caddy reload` I able to see the front page.